### PR TITLE
Vimify keymaps

### DIFF
--- a/event/src/event.rs
+++ b/event/src/event.rs
@@ -27,7 +27,7 @@ impl From<crossterm::event::Event> for Event {
 /// on combined modifier keys like Ctrl+Alt+Shift.
 ///
 /// The `crossterm` crate does not support this out of the box.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct KeyEvent {
     pub code: crossterm::event::KeyCode,
     pub modifiers: KeyModifiers,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1040,7 +1040,7 @@ impl<T: Frontend> App<T> {
                         .collect_vec(),
                 );
                 self.set_quickfix_list(
-                    ResponseContext::default().set_description("Bookmark"),
+                    ResponseContext::default().set_description("Marks"),
                     quickfix_list,
                 )
             }

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -1403,7 +1403,7 @@ impl Editor {
             Surround(open, close) => return self.enclose(open, close),
             ShowKeymapLegendNormalMode => {
                 return Ok([Dispatch::ShowKeymapLegend(
-                    self.normal_mode_keymap_legend_config(context)?,
+                    self.normal_mode_keymap_legend_config(context),
                 )]
                 .to_vec())
             }

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -15,6 +15,7 @@ use crate::{
     quickfix_list::QuickfixListType,
     selection::{FilterKind, FilterTarget, SelectionMode},
     selection_mode::inside::InsideKind,
+    transformation::Transformation,
 };
 
 use super::{
@@ -417,32 +418,53 @@ impl Editor {
             title: "Transform".to_string(),
             owner_id: self.id(),
             body: KeymapLegendBody::MultipleSections {
-                sections: [KeymapLegendSection {
-                    title: "Letter case".to_string(),
-                    keymaps: Keymaps::new(
-                        &[
-                            ("a", "aLtErNaTiNg CaSe", Case::Toggle),
-                            ("c", "camelCase", Case::Camel),
-                            ("l", "lowercase", Case::Lower),
-                            ("k", "kebab-case", Case::Kebab),
-                            ("K", "Upper-Kebab", Case::UpperKebab),
-                            ("p", "PascalCase", Case::Pascal),
-                            ("s", "snake_case", Case::Snake),
-                            ("S", "UPPER_SNAKE_CASE", Case::UpperSnake),
-                            ("t", "Title Case", Case::Title),
-                            ("u", "UPPERCASE", Case::Upper),
-                        ]
-                        .into_iter()
-                        .map(|(key, description, case)| {
+                sections: [
+                    KeymapLegendSection {
+                        title: "Letter case".to_string(),
+                        keymaps: Keymaps::new(
+                            &[
+                                ("a", "aLtErNaTiNg CaSe", Case::Toggle),
+                                ("c", "camelCase", Case::Camel),
+                                ("l", "lowercase", Case::Lower),
+                                ("k", "kebab-case", Case::Kebab),
+                                ("K", "Upper-Kebab", Case::UpperKebab),
+                                ("p", "PascalCase", Case::Pascal),
+                                ("s", "snake_case", Case::Snake),
+                                ("S", "UPPER_SNAKE_CASE", Case::UpperSnake),
+                                ("t", "Title Case", Case::Title),
+                                ("u", "UPPERCASE", Case::Upper),
+                            ]
+                            .into_iter()
+                            .map(|(key, description, case)| {
+                                Keymap::new(
+                                    key,
+                                    description.to_string(),
+                                    Dispatch::DispatchEditor(Transform(Transformation::Case(case))),
+                                )
+                            })
+                            .collect_vec(),
+                        ),
+                    },
+                    KeymapLegendSection {
+                        title: "Other".to_string(),
+                        keymaps: Keymaps::new(&[
                             Keymap::new(
-                                key,
-                                description.to_string(),
-                                Dispatch::DispatchEditor(Transform(case)),
-                            )
-                        })
-                        .collect_vec(),
-                    ),
-                }]
+                                "j",
+                                "Join".to_string(),
+                                Dispatch::DispatchEditor(DispatchEditor::Transform(
+                                    Transformation::Join,
+                                )),
+                            ),
+                            Keymap::new(
+                                "w",
+                                "Wrap".to_string(),
+                                Dispatch::DispatchEditor(DispatchEditor::Transform(
+                                    Transformation::Wrap,
+                                )),
+                            ),
+                        ]),
+                    },
+                ]
                 .to_vec(),
             },
         }

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -29,9 +29,14 @@ impl Editor {
     pub(crate) fn keymap_movements(&self) -> Vec<Keymap> {
         [
             Keymap::new(
-                "H",
-                "Highest (First)".to_string(),
+                ",",
+                "First".to_string(),
                 Dispatch::DispatchEditor(MoveSelection(First)),
+            ),
+            Keymap::new(
+                ".",
+                "Last".to_string(),
+                Dispatch::DispatchEditor(MoveSelection(Last)),
             ),
             Keymap::new(
                 "h",
@@ -54,21 +59,20 @@ impl Editor {
                 Dispatch::DispatchEditor(MoveSelection(Next)),
             ),
             Keymap::new(
-                "L",
-                "Lowest (Last)".to_string(),
-                Dispatch::DispatchEditor(MoveSelection(Last)),
-            ),
-            Keymap::new(
                 "s",
                 "Skip (Jump)".to_string(),
                 Dispatch::DispatchEditor(DispatchEditor::Jump),
             ),
             Keymap::new(
-                "-",
+                "p",
                 "Parent Line".to_string(),
                 Dispatch::DispatchEditor(MoveSelection(ToParentLine)),
             ),
-            Keymap::new("0", "To Index".to_string(), Dispatch::OpenMoveToIndexPrompt),
+            Keymap::new(
+                "0",
+                "To Index (1-based)".to_string(),
+                Dispatch::OpenMoveToIndexPrompt,
+            ),
         ]
         .to_vec()
     }
@@ -81,12 +85,12 @@ impl Editor {
                 Dispatch::ShowKeymapLegend(self.inside_mode_keymap_legend_config()),
             ),
             Keymap::new(
-                "e",
+                "y",
                 "Line (Trimmed)".to_string(),
                 Dispatch::DispatchEditor(SetSelectionMode(LineTrimmed)),
             ),
             Keymap::new(
-                "E",
+                "Y",
                 "Line (Full)".to_string(),
                 Dispatch::DispatchEditor(SetSelectionMode(LineFull)),
             ),
@@ -111,7 +115,7 @@ impl Editor {
                 Dispatch::DispatchEditor(SetSelectionMode(BottomNode)),
             ),
             Keymap::new(
-                "o",
+                "x",
                 "Column".to_string(),
                 Dispatch::DispatchEditor(SetSelectionMode(Character)),
             ),
@@ -135,18 +139,13 @@ impl Editor {
             Keymap::new("r", "Raise".to_string(), Dispatch::DispatchEditor(Raise)),
             Keymap::new(
                 "R",
-                "Replace".to_string(),
+                "Replace Cut".to_string(),
                 Dispatch::DispatchEditor(ReplaceCut),
             ),
             Keymap::new(
                 "u",
                 "Update".to_string(),
                 Dispatch::ShowKeymapLegend(self.update_keymap_legend_config()),
-            ),
-            Keymap::new(
-                "y",
-                "Yank (Copy)".to_string(),
-                Dispatch::DispatchEditor(Copy),
             ),
         ]
         .to_vec()
@@ -164,14 +163,19 @@ impl Editor {
                 Dispatch::DispatchEditor(EnterInsertMode(Direction::Start)),
             ),
             Keymap::new(
+                "e",
+                "Exchange".to_string(),
+                Dispatch::DispatchEditor(EnterExchangeMode),
+            ),
+            Keymap::new(
+                "o",
+                "Omnom (Eat)".to_string(),
+                Dispatch::DispatchEditor(EnterReplaceMode),
+            ),
+            Keymap::new(
                 "v",
                 "Visual (Extend selection)".to_string(),
                 Dispatch::DispatchEditor(ToggleHighlightMode),
-            ),
-            Keymap::new(
-                "x",
-                "Exchange".to_string(),
-                Dispatch::DispatchEditor(EnterExchangeMode),
             ),
             Keymap::new(
                 "z",
@@ -190,7 +194,7 @@ impl Editor {
             ),
             Keymap::new(
                 "q",
-                "Context menu".to_string(),
+                "Qontext menu".to_string(),
                 Dispatch::ShowKeymapLegend(self.context_menu_legend_config(context)),
             ),
             Keymap::new(
@@ -592,11 +596,6 @@ impl Editor {
                             Dispatch::ShowKeymapLegend(self.show_literal_keymap_legend_config()),
                         ),
                         Keymap::new(
-                            "o",
-                            "One character".to_string(),
-                            Dispatch::DispatchEditor(FindOneChar),
-                        ),
-                        Keymap::new(
                             "space",
                             "Empty line".to_string(),
                             Dispatch::DispatchEditor(SetSelectionMode(EmptyLine)),
@@ -633,6 +632,11 @@ impl Editor {
                                 "m",
                                 "Mark".to_string(),
                                 Dispatch::DispatchEditor(SetSelectionMode(Bookmark)),
+                            ),
+                            Keymap::new(
+                                "o",
+                                "One character".to_string(),
+                                Dispatch::DispatchEditor(FindOneChar),
                             ),
                             Keymap::new(
                                 "g",

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -30,8 +30,13 @@ impl Editor {
     pub(crate) fn keymap_movements(&self) -> Vec<Keymap> {
         [
             Keymap::new(
+                "H",
+                "Highest (First)".to_string(),
+                Dispatch::DispatchEditor(MoveSelection(First)),
+            ),
+            Keymap::new(
                 "h",
-                "Previous".to_string(),
+                "Higher (Previous)".to_string(),
                 Dispatch::DispatchEditor(MoveSelection(Movement::Previous)),
             ),
             Keymap::new(
@@ -46,12 +51,17 @@ impl Editor {
             ),
             Keymap::new(
                 "l",
-                "Next".to_string(),
+                "Lower (Next)".to_string(),
                 Dispatch::DispatchEditor(MoveSelection(Next)),
             ),
             Keymap::new(
-                "o",
-                "Oscillate (Jump)".to_string(),
+                "L",
+                "Lowest (Last)".to_string(),
+                Dispatch::DispatchEditor(MoveSelection(Last)),
+            ),
+            Keymap::new(
+                "s",
+                "Skip (Jump)".to_string(),
                 Dispatch::DispatchEditor(DispatchEditor::Jump),
             ),
             Keymap::new(
@@ -65,20 +75,11 @@ impl Editor {
                 Dispatch::DispatchEditor(MoveSelection(FirstChild)),
             ),
             Keymap::new(
-                ",",
-                "First".to_string(),
-                Dispatch::DispatchEditor(MoveSelection(First)),
-            ),
-            Keymap::new(
-                ".",
-                "Last".to_string(),
-                Dispatch::DispatchEditor(MoveSelection(Last)),
-            ),
-            Keymap::new(
                 "-",
                 "Parent Line".to_string(),
                 Dispatch::DispatchEditor(MoveSelection(ToParentLine)),
             ),
+            Keymap::new("0", "To Index".to_string(), Dispatch::OpenMoveToIndexPrompt),
         ]
         .to_vec()
     }
@@ -112,22 +113,17 @@ impl Editor {
             ),
             Keymap::new(
                 "n",
-                "Bottom Node".to_string(),
-                Dispatch::DispatchEditor(SetSelectionMode(BottomNode)),
-            ),
-            Keymap::new(
-                "s",
-                "Syntax Tree".to_string(),
+                "Node".to_string(),
                 Dispatch::DispatchEditor(SetSelectionMode(SyntaxTree)),
             ),
             Keymap::new(
                 "t",
-                "Top Node".to_string(),
-                Dispatch::DispatchEditor(SetSelectionMode(TopNode)),
+                "Token".to_string(),
+                Dispatch::DispatchEditor(SetSelectionMode(BottomNode)),
             ),
             Keymap::new(
                 "u",
-                "Character".to_string(),
+                "Column".to_string(),
                 Dispatch::DispatchEditor(SetSelectionMode(Character)),
             ),
             Keymap::new(

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -125,38 +125,6 @@ impl Editor {
         }
     }
 
-    pub fn x_mode_keymap_legend_config(&self) -> anyhow::Result<KeymapLegendConfig> {
-        Ok(KeymapLegendConfig {
-            title: "X (Regex/Bracket/Quote)".to_string(),
-            owner_id: self.id(),
-            body: KeymapLegendBody::SingleSection {
-                keymaps: Keymaps::new(
-                    &[
-                        Keymap::new(
-                            "e",
-                            "Empty line".to_string(),
-                            Dispatch::DispatchEditor(DispatchEditor::SetSelectionMode(
-                                SelectionMode::EmptyLine,
-                            )),
-                        ),
-                        Keymap::new(
-                            "n",
-                            "Number".to_string(),
-                            Dispatch::ShowKeymapLegend(self.show_number_keymap_legend_config()),
-                        ),
-                        Keymap::new(
-                            "o",
-                            "One character".to_string(),
-                            Dispatch::DispatchEditor(DispatchEditor::FindOneChar),
-                        ),
-                    ]
-                    .into_iter()
-                    .collect_vec(),
-                ),
-            },
-        })
-    }
-
     fn diagnostics_keymap(&self, scope: Scope) -> KeymapLegendSection {
         let keymaps = [
             ("a", "Any", None),
@@ -205,7 +173,7 @@ impl Editor {
                         &[
                             Keymap::new(
                                 "b",
-                                "Bookmark".to_string(),
+                                "Mark".to_string(),
                                 Dispatch::DispatchEditor(DispatchEditor::SetSelectionMode(
                                     SelectionMode::Bookmark,
                                 )),
@@ -241,6 +209,23 @@ impl Editor {
                                     owner_id: self.id(),
                                     scope: Scope::Local,
                                 },
+                            ),
+                            Keymap::new(
+                                "space",
+                                "Empty line".to_string(),
+                                Dispatch::DispatchEditor(DispatchEditor::SetSelectionMode(
+                                    SelectionMode::EmptyLine,
+                                )),
+                            ),
+                            Keymap::new(
+                                "n",
+                                "Number".to_string(),
+                                Dispatch::ShowKeymapLegend(self.show_number_keymap_legend_config()),
+                            ),
+                            Keymap::new(
+                                "o",
+                                "One character".to_string(),
+                                Dispatch::DispatchEditor(DispatchEditor::FindOneChar),
                             ),
                         ]
                         .into_iter()
@@ -386,13 +371,13 @@ impl Editor {
             body: KeymapLegendBody::SingleSection {
                 keymaps: Keymaps::new(
                     &[
-                        ("a", "Angular Bracket <>", InsideKind::AngularBrackets),
-                        ("b", "Back Quote ``", InsideKind::BackQuotes),
-                        ("c", "Curly Brace {}", InsideKind::CurlyBraces),
-                        ("d", "Double Quote \"\"", InsideKind::DoubleQuotes),
-                        ("p", "Parenthesis ()", InsideKind::Parentheses),
-                        ("q", "Single Quote ''", InsideKind::SingleQuotes),
-                        ("s", "Square Bracket []", InsideKind::SquareBrackets),
+                        ("<", "Angular Bracket <>", InsideKind::AngularBrackets),
+                        ("`", "Back Quote ``", InsideKind::BackQuotes),
+                        ("{", "Curly Brace {}", InsideKind::CurlyBraces),
+                        ("\"", "Double Quote \"\"", InsideKind::DoubleQuotes),
+                        ("(", "Parenthesis ()", InsideKind::Parentheses),
+                        ("'", "Single Quote ''", InsideKind::SingleQuotes),
+                        ("[", "Square Bracket []", InsideKind::SquareBrackets),
                     ]
                     .into_iter()
                     .map(|(key, description, inside_kind)| {

--- a/src/components/editor_keymap_legend.rs
+++ b/src/components/editor_keymap_legend.rs
@@ -41,12 +41,12 @@ impl Editor {
             ),
             Keymap::new(
                 "j",
-                "Down".to_string(),
+                "Down / First Child".to_string(),
                 Dispatch::DispatchEditor(MoveSelection(Down)),
             ),
             Keymap::new(
                 "k",
-                "Up".to_string(),
+                "Up / Parent".to_string(),
                 Dispatch::DispatchEditor(MoveSelection(Up)),
             ),
             Keymap::new(
@@ -63,16 +63,6 @@ impl Editor {
                 "s",
                 "Skip (Jump)".to_string(),
                 Dispatch::DispatchEditor(DispatchEditor::Jump),
-            ),
-            Keymap::new(
-                "p",
-                "Parent".to_string(),
-                Dispatch::DispatchEditor(MoveSelection(Parent)),
-            ),
-            Keymap::new(
-                "q",
-                "First Child".to_string(),
-                Dispatch::DispatchEditor(MoveSelection(FirstChild)),
             ),
             Keymap::new(
                 "-",

--- a/src/components/keymap_legend.rs
+++ b/src/components/keymap_legend.rs
@@ -56,7 +56,7 @@ impl Keymaps {
         let result = self
             .0
             .iter()
-            .sorted_by_key(|keymap| keymap.key.to_lowercase())
+            // .sorted_by_key(|keymap| keymap.key.to_lowercase())
             .map(|keymap| {
                 let formatted = format!(
                     "{: >width$}{}{}",
@@ -88,6 +88,10 @@ impl Keymaps {
 
     pub fn new(keymaps: &[Keymap]) -> Self {
         Self(keymaps.to_vec())
+    }
+
+    pub(crate) fn get(&self, event: &KeyEvent) -> std::option::Option<&Keymap> {
+        self.0.iter().find(|key| &key.event == event)
     }
 }
 
@@ -179,6 +183,10 @@ impl Keymap {
             dispatch,
             event: parse_key_event(key).unwrap(),
         }
+    }
+
+    pub(crate) fn dispatch(&self) -> Dispatch {
+        self.dispatch.clone()
     }
 }
 

--- a/src/components/keymap_legend.rs
+++ b/src/components/keymap_legend.rs
@@ -162,7 +162,7 @@ impl KeymapLegendConfig {
         self.body.display(width)
     }
 
-    fn keymaps(&self) -> Vec<&Keymap> {
+    pub fn keymaps(&self) -> Vec<&Keymap> {
         self.body.keymaps()
     }
 }

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -29,21 +29,17 @@ mod test_editor {
 
     #[test]
     fn raise_bottom_node() -> anyhow::Result<()> {
-        let input = "fn main() { x + 1 }";
-        let mut editor = Editor::from_text(language(), input);
-        let mut context = Context::default();
-        editor.apply_dispatches(
-            &mut context,
-            [
-                MatchLiteral("x + 1".to_string()),
-                SetSelectionMode(SelectionMode::TopNode),
-                MoveSelection(Movement::Down),
-                Raise,
-            ]
-            .to_vec(),
-        )?;
-        assert_eq!(editor.content(), "fn main() { x }");
-        Ok(())
+        execute_test(|s| {
+            let input = "fn main() { x + 1 }";
+            Box::new([
+                App(OpenFile(s.main_rs())),
+                Editor(SetContent(input.to_string())),
+                Editor(MatchLiteral("x".to_string())),
+                Editor(SetSelectionMode(SelectionMode::BottomNode)),
+                Editor(Raise),
+                Expect(CurrentComponentContent("fn main() { x }")),
+            ])
+        })
     }
 
     #[test]
@@ -340,9 +336,9 @@ mod test_editor {
                     "fn f(x:a,y:b){}",
                     "fn g(x:a,y:b){}",
                 ])),
-                Editor(MoveSelection(Down)),
+                Editor(MoveSelection(FirstChild)),
                 Editor(MoveSelection(Next)),
-                Editor(MoveSelection(Down)),
+                Editor(MoveSelection(FirstChild)),
                 Expect(CurrentSelectedTexts(&["x:a", "x:a"])),
                 Editor(SetSelectionMode(SyntaxTree)),
                 Editor(EnterExchangeMode),
@@ -519,11 +515,11 @@ mod test_editor {
                 Editor(MatchLiteral("let x = S(a);".to_string())),
                 Editor(SetSelectionMode(SyntaxTree)),
                 Editor(CursorAddToAllSelections),
-                Editor(MoveSelection(Down)),
+                Editor(MoveSelection(FirstChild)),
                 Editor(MoveSelection(Next)),
-                Editor(MoveSelection(Down)),
+                Editor(MoveSelection(FirstChild)),
                 Editor(MoveSelection(Next)),
-                Editor(MoveSelection(Down)),
+                Editor(MoveSelection(FirstChild)),
                 Editor(MoveSelection(Next)),
                 Expect(CurrentSelectedTexts(&["a", "b"])),
                 Editor(Raise),
@@ -614,13 +610,15 @@ fn main() {
                 App(OpenFile(s.main_rs())),
                 Editor(SetContent("fn main() { let x = 1; }".to_string())),
                 Editor(SetSelectionMode(Character)),
-                Editor(Exchange(Next)),
+                Editor(EnterExchangeMode),
+                App(HandleKeyEvent(key!("l"))),
+                // Editor(MoveSelection(Next)),
                 Expect(CurrentComponentContent("nf main() { let x = 1; }")),
-                Editor(Exchange(Next)),
+                Editor(MoveSelection(Next)),
                 Expect(CurrentComponentContent("n fmain() { let x = 1; }")),
-                Editor(Exchange(Previous)),
+                Editor(MoveSelection(Previous)),
                 Expect(CurrentComponentContent("nf main() { let x = 1; }")),
-                Editor(Exchange(Previous)),
+                Editor(MoveSelection(Previous)),
                 Expect(CurrentComponentContent("fn main() { let x = 1; }")),
             ])
         })
@@ -738,9 +736,9 @@ fn main() {
                 Editor(SetSelectionMode(SyntaxTree)),
                 Expect(CurrentSelectedTexts(&["fn a(j:J){}"])),
                 Editor(CursorAddToAllSelections),
-                Editor(MoveSelection(Down)),
+                Editor(MoveSelection(FirstChild)),
                 Editor(MoveSelection(Next)),
-                Editor(MoveSelection(Down)),
+                Editor(MoveSelection(FirstChild)),
                 Expect(CurrentSelectedTexts(&["j:J", "k:K", "m:M"])),
                 Editor(CursorAddToAllSelections),
                 Expect(CurrentSelectedTexts(&[

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -1331,24 +1331,11 @@ src/main.rs 🦀
                 Editor(SetContent("fn main() { x.y() }".to_string())),
                 Editor(MatchLiteral("x.y()".to_string())),
                 App(HandleKeyEvents(keys!("( { [ < ' `").to_vec())),
+                App(HandleKeyEvent(key!('"'))),
                 Expect(CurrentComponentContent(
-                    "fn main() { `\"'<[{(x.y())}]>'\"` }",
+                    "fn main() { \"`'<[{(x.y())}]>'`\" }",
                 )),
-                Expect(CurrentSelectedTexts(&["`\"'<[{(x.y())}]>'\"`"])),
-            ])
-        })
-    }
-
-    #[test]
-    fn enclose_right_bracket() -> anyhow::Result<()> {
-        execute_test(|s| {
-            Box::new([
-                App(OpenFile(s.main_rs())),
-                Editor(SetContent("fn main() { x.y() }".to_string())),
-                Editor(MatchLiteral("x.y()".to_string())),
-                App(HandleKeyEvents(keys!(") } ] >").to_vec())),
-                Expect(CurrentComponentContent("fn main() { <[{(x.y())}]> }")),
-                Expect(CurrentSelectedTexts(&["<[{(x.y())}]>"])),
+                Expect(CurrentSelectedTexts(&["\"`'<[{(x.y())}]>'`\""])),
             ])
         })
     }

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -1324,15 +1324,17 @@ src/main.rs 🦀
     }
 
     #[test]
-    fn enclose_left_bracket() -> anyhow::Result<()> {
+    fn surround() -> anyhow::Result<()> {
         execute_test(|s| {
             Box::new([
                 App(OpenFile(s.main_rs())),
                 Editor(SetContent("fn main() { x.y() }".to_string())),
                 Editor(MatchLiteral("x.y()".to_string())),
-                App(HandleKeyEvents(keys!("( { [ <").to_vec())),
-                Expect(CurrentComponentContent("fn main() { <[{(x.y())}]> }")),
-                Expect(CurrentSelectedTexts(&["<[{(x.y())}]>"])),
+                App(HandleKeyEvents(keys!("( { [ < ' `").to_vec())),
+                Expect(CurrentComponentContent(
+                    "fn main() { `\"'<[{(x.y())}]>'\"` }",
+                )),
+                Expect(CurrentSelectedTexts(&["`\"'<[{(x.y())}]>'\"`"])),
             ])
         })
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ pub mod syntax_highlight;
 mod terminal;
 mod test_app;
 pub mod themes;
+pub mod transformation;
 pub mod undo_tree;
 mod utils;
 

--- a/src/selection_mode/bottom_node.rs
+++ b/src/selection_mode/bottom_node.rs
@@ -23,16 +23,11 @@ impl SelectionMode for BottomNode {
         ))
     }
 
-    fn up(
+    fn parent(
         &self,
         params: super::SelectionModeParams,
-    ) -> anyhow::Result<Option<super::ApplyMovementResult>> {
-        Ok(TopNode
-            .current(params)?
-            .map(|selection| ApplyMovementResult {
-                selection,
-                mode: Some(crate::selection::SelectionMode::TopNode),
-            }))
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        TopNode.current(params)
     }
 }
 

--- a/src/selection_mode/inside.rs
+++ b/src/selection_mode/inside.rs
@@ -41,6 +41,23 @@ impl SelectionMode for Inside {
         Ok(pair.map(|pair| current_selection.clone().set_range(pair.inner_range())))
     }
 
+    fn up(
+        &self,
+        params: super::SelectionModeParams,
+    ) -> anyhow::Result<Option<super::ApplyMovementResult>> {
+        Ok(self
+            .parent(params)?
+            .map(super::ApplyMovementResult::from_selection))
+    }
+    fn down(
+        &self,
+        params: super::SelectionModeParams,
+    ) -> anyhow::Result<Option<super::ApplyMovementResult>> {
+        Ok(self
+            .first_child(params)?
+            .map(super::ApplyMovementResult::from_selection))
+    }
+
     fn parent(&self, params: SelectionModeParams) -> anyhow::Result<Option<Selection>> {
         let SelectionModeParams {
             current_selection, ..

--- a/src/selection_mode/inside.rs
+++ b/src/selection_mode/inside.rs
@@ -5,7 +5,7 @@ use crate::{
     selection::Selection,
 };
 
-use super::{ApplyMovementResult, SelectionMode, SelectionModeParams};
+use super::{SelectionMode, SelectionModeParams};
 
 pub struct Inside(pub InsideKind);
 
@@ -31,16 +31,17 @@ impl SelectionMode for Inside {
         SelectionModeParams {
             buffer,
             current_selection,
+            cursor_direction,
             ..
         }: SelectionModeParams,
     ) -> anyhow::Result<Option<Selection>> {
         let (open, close) = self.0.open_close_symbols();
-        let range = current_selection.extended_range();
-        let pair = buffer.find_nearest_pair(range, &open, &close);
+        let range = current_selection.get_anchor(cursor_direction);
+        let pair = buffer.find_nearest_pair((range..range).into(), &open, &close);
         Ok(pair.map(|pair| current_selection.clone().set_range(pair.inner_range())))
     }
 
-    fn up(&self, params: SelectionModeParams) -> anyhow::Result<Option<ApplyMovementResult>> {
+    fn parent(&self, params: SelectionModeParams) -> anyhow::Result<Option<Selection>> {
         let SelectionModeParams {
             current_selection, ..
         } = params;
@@ -49,9 +50,7 @@ impl SelectionMode for Inside {
         let (open, close) = self.0.open_close_symbols();
         let range = current_selection.extended_range();
         if text.starts_with(&open) && text.ends_with(&close) {
-            return Ok(self
-                .current(params)?
-                .map(ApplyMovementResult::from_selection));
+            return self.current(params);
         }
 
         let start = range.start - open.chars().count();
@@ -59,12 +58,10 @@ impl SelectionMode for Inside {
 
         let range: CharIndexRange = (start..end).into();
 
-        Ok(Some(ApplyMovementResult::from_selection(
-            current_selection.clone().set_range(range),
-        )))
+        Ok(Some(current_selection.clone().set_range(range)))
     }
 
-    fn down(&self, params: SelectionModeParams) -> anyhow::Result<Option<ApplyMovementResult>> {
+    fn first_child(&self, params: SelectionModeParams) -> anyhow::Result<Option<Selection>> {
         let SelectionModeParams {
             buffer,
             current_selection,
@@ -92,9 +89,7 @@ impl SelectionMode for Inside {
                 })
                 .map(|pair| pair.outer_range())
         };
-        Ok(range.map(|range| {
-            ApplyMovementResult::from_selection(current_selection.clone().set_range(range))
-        }))
+        Ok(range.map(|range| current_selection.clone().set_range(range)))
     }
 }
 
@@ -207,7 +202,7 @@ mod test_inside {
     }
 
     #[test]
-    fn up() -> anyhow::Result<()> {
+    fn parent() -> anyhow::Result<()> {
         let buffer = Buffer::new(tree_sitter_rust::language(), "a b {|c {|d e|}|}");
         let inside = Inside(InsideKind::Other {
             open: "{|".to_string(),
@@ -216,7 +211,7 @@ mod test_inside {
 
         let ups = inside.generate_selections(
             &buffer,
-            Movement::Up,
+            Movement::Parent,
             3,
             (CharIndex(10)..CharIndex(13)).into(),
         )?;
@@ -226,7 +221,7 @@ mod test_inside {
     }
 
     #[test]
-    fn down() -> anyhow::Result<()> {
+    fn first_child() -> anyhow::Result<()> {
         let buffer = Buffer::new(tree_sitter_rust::language(), "a b {|c {|d e|}|} {| x |}");
         let inside = Inside(InsideKind::Other {
             open: "{|".to_string(),
@@ -235,7 +230,7 @@ mod test_inside {
 
         let downs = inside.generate_selections(
             &buffer,
-            Movement::Down,
+            Movement::FirstChild,
             3,
             (CharIndex(4)..CharIndex(17)).into(),
         )?;

--- a/src/selection_mode/line_full.rs
+++ b/src/selection_mode/line_full.rs
@@ -6,16 +6,11 @@ impl SelectionMode for LineFull {
     fn name(&self) -> &'static str {
         "LINE(FULL)"
     }
-    fn down(
+    fn first_child(
         &self,
         params: super::SelectionModeParams,
-    ) -> anyhow::Result<Option<super::ApplyMovementResult>> {
-        Ok(LineTrimmed
-            .apply_movement(params, crate::components::editor::Movement::Current)?
-            .map(|result| ApplyMovementResult {
-                selection: result.selection,
-                mode: Some(crate::selection::SelectionMode::LineTrimmed),
-            }))
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        LineTrimmed.current(params)
     }
     fn iter<'a>(
         &'a self,

--- a/src/selection_mode/line_trimmed.rs
+++ b/src/selection_mode/line_trimmed.rs
@@ -6,16 +6,11 @@ impl SelectionMode for LineTrimmed {
     fn name(&self) -> &'static str {
         "LINE(TRIMMED)"
     }
-    fn up(
+    fn parent(
         &self,
         params: super::SelectionModeParams,
-    ) -> anyhow::Result<Option<ApplyMovementResult>> {
-        Ok(LineFull
-            .apply_movement(params, crate::components::editor::Movement::Current)?
-            .map(|result| ApplyMovementResult {
-                selection: result.selection,
-                mode: Some(crate::selection::SelectionMode::LineFull),
-            }))
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        LineFull.current(params)
     }
     fn iter<'a>(
         &'a self,

--- a/src/selection_mode/mod.rs
+++ b/src/selection_mode/mod.rs
@@ -184,7 +184,17 @@ pub trait SelectionMode {
             Movement::Up => self.up(params),
             Movement::Down => self.down(params),
             Movement::ToParentLine => convert(self.to_parent_line(params)),
+            Movement::Parent => convert(self.parent(params)),
+            Movement::FirstChild => convert(self.first_child(params)),
         }
+    }
+
+    fn parent(&self, _: SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        Ok(None)
+    }
+
+    fn first_child(&self, _: SelectionModeParams) -> anyhow::Result<Option<Selection>> {
+        Ok(None)
     }
 
     fn to_parent_line(&self, params: SelectionModeParams) -> anyhow::Result<Option<Selection>> {

--- a/src/selection_mode/syntax_tree.rs
+++ b/src/selection_mode/syntax_tree.rs
@@ -43,6 +43,22 @@ impl SelectionMode for SyntaxTree {
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
         super::TopNode.current(params)
     }
+    fn up(
+        &self,
+        params: super::SelectionModeParams,
+    ) -> anyhow::Result<Option<super::ApplyMovementResult>> {
+        Ok(self
+            .parent(params)?
+            .map(super::ApplyMovementResult::from_selection))
+    }
+    fn down(
+        &self,
+        params: super::SelectionModeParams,
+    ) -> anyhow::Result<Option<super::ApplyMovementResult>> {
+        Ok(self
+            .first_child(params)?
+            .map(super::ApplyMovementResult::from_selection))
+    }
     fn parent(
         &self,
         params: super::SelectionModeParams,

--- a/src/selection_mode/syntax_tree.rs
+++ b/src/selection_mode/syntax_tree.rs
@@ -1,12 +1,23 @@
 use crate::selection::Selection;
 
-use super::{ByteRange, SelectionMode};
+use super::{ByteRange, SelectionMode, TopNode};
 
 pub struct SyntaxTree;
 
 impl SelectionMode for SyntaxTree {
     fn name(&self) -> &'static str {
         "SYNTAX TREE"
+    }
+    fn jumps(
+        &self,
+        params: super::SelectionModeParams,
+        chars: Vec<char>,
+        line_number_range: std::ops::Range<usize>,
+    ) -> anyhow::Result<Vec<crate::components::editor::Jump>> {
+        // Why do we use TopNode.jumps?
+        // Because I realize I only use TopNode for jumping, and I never use jump in SyntaxTree
+        // With this decision, TopNode selection mode can be removed from user-space, and we get one more keymap space
+        TopNode.jumps(params, chars, line_number_range)
     }
     fn iter<'a>(
         &'a self,

--- a/src/selection_mode/top_node.rs
+++ b/src/selection_mode/top_node.rs
@@ -1,4 +1,5 @@
-use super::{ApplyMovementResult, BottomNode, ByteRange, SelectionMode};
+use super::SyntaxTree;
+use super::{BottomNode, ByteRange, SelectionMode};
 use itertools::Itertools;
 
 pub struct TopNode;
@@ -40,6 +41,13 @@ impl SelectionMode for TopNode {
         params: super::SelectionModeParams,
     ) -> anyhow::Result<Option<crate::selection::Selection>> {
         BottomNode.current(params)
+    }
+
+    fn parent(
+        &self,
+        params: super::SelectionModeParams,
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        SyntaxTree.parent(params)
     }
 }
 

--- a/src/selection_mode/top_node.rs
+++ b/src/selection_mode/top_node.rs
@@ -35,16 +35,11 @@ impl SelectionMode for TopNode {
         ))
     }
 
-    fn down(
+    fn first_child(
         &self,
         params: super::SelectionModeParams,
-    ) -> anyhow::Result<Option<super::ApplyMovementResult>> {
-        Ok(BottomNode
-            .current(params)?
-            .map(|selection| ApplyMovementResult {
-                selection,
-                mode: Some(crate::selection::SelectionMode::BottomNode),
-            }))
+    ) -> anyhow::Result<Option<crate::selection::Selection>> {
+        BottomNode.current(params)
     }
 }
 

--- a/src/soft_wrap.rs
+++ b/src/soft_wrap.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use regex::Regex;
 use unicode_width::UnicodeWidthStr;
 
@@ -53,6 +54,15 @@ impl WrappedLines {
         &self.lines
     }
 
+    pub fn to_string(&self) -> String {
+        self.lines
+            .iter()
+            .map(|line| line.to_string())
+            .collect_vec()
+            .join("\n")
+            .to_string()
+    }
+
     pub(crate) fn wrapped_lines_count(&self) -> usize {
         self.lines.iter().map(|line| line.count()).sum()
     }
@@ -75,6 +85,10 @@ impl WrappedLine {
 
     pub fn line_number(&self) -> usize {
         self.line_number
+    }
+
+    pub fn to_string(&self) -> String {
+        self.lines().join("\n").to_string()
     }
 
     fn get_position(&self, column: usize, width: usize) -> Option<Position> {

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -543,7 +543,7 @@ pub mod test_app {
                 Editor(MatchLiteral("let x = S(spongebob_squarepants);".to_owned())),
                 Editor(SetSelectionMode(SelectionMode::SyntaxTree)),
                 Editor(CursorAddToAllSelections),
-                Editor(MoveSelection(Movement::Down)),
+                Editor(MoveSelection(Movement::FirstChild)),
                 Editor(MoveSelection(Movement::Next)),
                 Expect(CurrentSelectedTexts(&["S(spongebob_squarepants)", "S(b)"])),
                 Editor(Cut),

--- a/src/transformation.rs
+++ b/src/transformation.rs
@@ -1,0 +1,54 @@
+use convert_case::Casing;
+
+use crate::soft_wrap::soft_wrap;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Transformation {
+    Case(convert_case::Case),
+    Join,
+    Wrap,
+}
+impl Transformation {
+    pub fn apply(&self, string: String) -> String {
+        match self {
+            Transformation::Case(case) => string.to_case(case.clone()),
+            Transformation::Join => regex::Regex::new(r"\s*\n+\s*")
+                .unwrap()
+                .replace_all(&string, " ")
+                .to_string(),
+            Transformation::Wrap => soft_wrap(&string, 80).to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_transformation {
+    use super::Transformation;
+
+    #[test]
+    fn join() {
+        let result = Transformation::Join.apply(
+            "
+who 
+  lives
+    in 
+      a
+
+pineapple?
+"
+            .trim()
+            .to_string(),
+        );
+        assert_eq!(result, "who lives in a pineapple?")
+    }
+
+    #[test]
+    fn wrap() {
+        let result = Transformation::Wrap
+            .apply("
+who lives in a pineapple under the sea? Spongebob Squarepants! absorbent and yellow and porous is he? Spongebob Squarepants
+"
+            .trim().to_string());
+        assert_eq!(result, "who lives in a pineapple under the sea? Spongebob Squarepants! absorbent and \nyellow and porous is he? Spongebob Squarepants")
+    }
+}

--- a/src/undo_tree.rs
+++ b/src/undo_tree.rs
@@ -89,6 +89,12 @@ impl<T: Applicable> UndoTree<T> {
             Movement::ToParentLine => Err(anyhow::anyhow!(
                 "UndoTree: moving to ParentLine is not supported yet",
             )),
+            Movement::Parent => Err(anyhow::anyhow!(
+                "UndoTree: moving to Parent is not supported yet",
+            )),
+            Movement::FirstChild => Err(anyhow::anyhow!(
+                "UndoTree: moving to FirstChild is not supported yet",
+            )),
         }
     }
 

--- a/todo.md
+++ b/todo.md
@@ -272,3 +272,5 @@
 - [] feat(movement): [ = first selection in previous file, ] = first selection in next file
 - [] fix(code_action): not showing menu everytime properly
 - [] feat(syntax-tree): another mode to includes nameless sibling
+- [] crazy: why not pressing selection mode straigt away jump?
+- [] style: color based on regex capture (use this to style keymap legend)

--- a/todo.md
+++ b/todo.md
@@ -270,3 +270,4 @@
 - [] feat(editor): select around brackets
 - [] feat(surround): put [({< under the transformation keymap
 - [] feat(movement): [ = first selection in previous file, ] = first selection in next file
+- [] fix(code_action): not showing menu everytime properly

--- a/todo.md
+++ b/todo.md
@@ -271,3 +271,4 @@
 - [] feat(surround): put [({< under the transformation keymap
 - [] feat(movement): [ = first selection in previous file, ] = first selection in next file
 - [] fix(code_action): not showing menu everytime properly
+- [] feat(syntax-tree): another mode to includes nameless sibling

--- a/todo.md
+++ b/todo.md
@@ -268,3 +268,5 @@
 - [] feat: mouse selection
 - [] fix(completion): browsing selections, selection always aligned to top
 - [] feat(editor): select around brackets
+- [] feat(surround): put [({< under the transformation keymap
+- [] feat(movement): [ = first selection in previous file, ] = first selection in next file


### PR DESCRIPTION
In this PR, the keymaps are rebound to be as close as Vim's keybinding to reduce learning friction.