### PR TITLE
feat(code_action): show as prompt

### DIFF
--- a/src/components/dropdown.rs
+++ b/src/components/dropdown.rs
@@ -294,10 +294,6 @@ impl Dropdown {
     pub(crate) fn items(&self) -> Vec<DropdownItem> {
         self.items.clone()
     }
-
-    pub(crate) fn clear(&mut self) {
-        self.set_items(Default::default())
-    }
 }
 
 #[cfg(test)]

--- a/src/lsp/code_action.rs
+++ b/src/lsp/code_action.rs
@@ -1,3 +1,10 @@
+use itertools::Itertools;
+
+use crate::{
+    app::{Dispatch, RequestParams},
+    components::dropdown::DropdownItem,
+};
+
 use super::workspace_edit::WorkspaceEdit;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -32,6 +39,35 @@ impl Eq for Command {}
 impl CodeAction {
     pub fn title(&self) -> String {
         self.title.clone()
+    }
+    pub fn into_dropdown_item(self, params: Option<RequestParams>) -> DropdownItem {
+        let value = self;
+        DropdownItem {
+            rank: None,
+            info: None,
+            display: value.title,
+            group: Some(
+                value
+                    .kind
+                    .and_then(|kind| if kind.is_empty() { None } else { Some(kind) })
+                    .unwrap_or("Misc.".to_string()),
+            ),
+            dispatches: value
+                .edit
+                .map(Dispatch::ApplyWorkspaceEdit)
+                .into_iter()
+                // A command this code action executes. If a code action
+                // provides an edit and a command, first the edit is
+                // executed and then the command.
+                // Refer https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeAction
+                .chain(params.and_then(|params| {
+                    value
+                        .command
+                        .map(|command| Dispatch::LspExecuteCommand { command, params })
+                }))
+                .collect_vec()
+                .into(),
+        }
     }
 }
 


### PR DESCRIPTION
So that the user can search code action instead of navigating one by one.