### PR TITLE
feat(render): unicode grapheme cluster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2046,6 +2046,7 @@ dependencies = [
  "tree-sitter-traversal",
  "tree-sitter-typescript",
  "undo",
+ "unicode-segmentation",
  "unicode-width",
  "uuid",
  "vt100",
@@ -2223,9 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ similar = {version = "2.4.0", features = ["unicode", "inline"]}
 indexmap = "2.2.2"
 globset = "0.4.14"
 unicode-width = "0.1.11"
+unicode-segmentation = "1.11.0"
 
 
 [dev-dependencies]


### PR DESCRIPTION
TODO:
- check why rendering becomes faulty, see attached image for example

![image](https://github.com/wongjiahau/treeman/assets/23183656/89aaaa2c-fb59-4a63-a4e3-cf2a9860bd2e)
