### PR TITLE
fix(render): decorations of hidden parent lines polluting other parts

### DIFF
--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -1916,16 +1916,7 @@ impl Editor {
                 self.mode = Mode::Normal;
                 Ok(Default::default())
             }
-            // Look here!
-            // TODO: put this into keymap legend
-            key!("a") => {
-                self.add_cursor_to_all_selections()?;
-                Ok(Default::default())
-            }
-            key!("o") => {
-                self.cursor_keep_primary_only();
-                Ok(Default::default())
-            }
+
             other => self.handle_normal_mode(context, other),
         }
     }

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -1133,6 +1133,19 @@ fn main() {
             // Expect the bookmarks of inbound lines are rendered properly
             // In this case, we want to check that the bookmark on "z" is rendered
             Expect(GridCellBackground(4, 10, bookmark_background_color)),
+            // Expect no cells of the line `let y = 2` is not decorated with `bookmark_background_color`
+            ExpectMulti(
+                (0..12)
+                    .into_iter()
+                    .map(|column_index| {
+                        Not(Box::new(GridCellBackground(
+                            2,
+                            column_index,
+                            bookmark_background_color,
+                        )))
+                    })
+                    .collect(),
+            ),
         ])
     })
 }

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -1136,7 +1136,6 @@ fn main() {
             // Expect no cells of the line `let y = 2` is not decorated with `bookmark_background_color`
             ExpectMulti(
                 (0..12)
-                    .into_iter()
                     .map(|column_index| {
                         Not(Box::new(GridCellBackground(
                             2,


### PR DESCRIPTION
This is done by not passing hidden parent lines updates when rendering visible lines and vice versa.