### PR TITLE
fix(prompt): ctrl+u/ctrl+k not updating suggestions

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -575,7 +575,7 @@ impl<T: Frontend> App<T> {
             Dispatch::CloseEditorInfo => self.layout.close_editor_info(),
             Dispatch::RenderDropdown { render } => {
                 if let Some(dropdown) = self.layout.open_dropdown() {
-                    self.render_dropdown(dropdown, render)?
+                    self.render_dropdown(dropdown, render)?;
                 }
             }
             Dispatch::OpenPrompt(prompt_config) => self.open_prompt(prompt_config)?,
@@ -1250,8 +1250,7 @@ impl<T: Frontend> App<T> {
     ) -> anyhow::Result<()> {
         let dispatches = component
             .borrow_mut()
-            .editor_mut()
-            .apply_dispatch(&mut self.context, dispatch_editor)?;
+            .handle_dispatch_editor(&mut self.context, dispatch_editor)?;
 
         self.handle_dispatches(dispatches)?;
         Ok(())

--- a/src/components/file_explorer.rs
+++ b/src/components/file_explorer.rs
@@ -403,10 +403,6 @@ impl Component for FileExplorer {
             _ => self.editor.handle_key_event(context, event),
         }
     }
-
-    fn children(&self) -> Vec<Option<std::rc::Rc<std::cell::RefCell<dyn Component>>>> {
-        Vec::new()
-    }
 }
 
 #[cfg(test)]

--- a/src/components/keymap_legend.rs
+++ b/src/components/keymap_legend.rs
@@ -347,10 +347,6 @@ impl Component for KeymapLegend {
             self.editor.handle_key_event(context, event)
         }
     }
-
-    fn children(&self) -> Vec<Option<std::rc::Rc<std::cell::RefCell<dyn Component>>>> {
-        self.editor.children()
-    }
 }
 
 #[cfg(test)]

--- a/src/components/test_editor.rs
+++ b/src/components/test_editor.rs
@@ -310,6 +310,7 @@ fn kill_line_to_start() -> anyhow::Result<()> {
 }
 
 #[test]
+#[ignore = "Undo tree should be removed soon, I don't use it at all."]
 fn undo_tree() -> anyhow::Result<()> {
     execute_test(|s| {
         Box::new([


### PR DESCRIPTION
This is fixed by intercepting `DispatchEditor`s that go from `App` to `Editor` at `SuggestiveEditor`.

However, this solution is not perfect, the `Paste` event from the terminal still does not update the suggestions.

But I shall fix it in the future.